### PR TITLE
Example for typescript bundle with modules

### DIFF
--- a/typescript-module-bundle/.gitignore
+++ b/typescript-module-bundle/.gitignore
@@ -1,0 +1,4 @@
+.edgerc
+
+node_modules
+dist

--- a/typescript-module-bundle/README.md
+++ b/typescript-module-bundle/README.md
@@ -1,0 +1,78 @@
+# typescript-module-bundle
+
+*Keyword(s):* typescript, rollup.js, code importing, es module, commonjs module, bundle<br>
+*[Since](https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-14077BCA-0D9F-422C-8273-2F3E37339D5B.html):* 1.0
+
+This is an example that demonstrates how to build an edge worker that is written in TypeScript.
+
+## Use Cases
+
+- You are developing EdgeWorkers in TypeScript.
+- You are structuring your code in modules.
+- You have dependencies on third-party CommonJS modules.
+
+## Overview
+
+Akamai EdgeWorkers provides [TypeScript support](https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-EFA9EC25-AF64-4552-9D4D-BFE5E9D82752.html). However, if we structure our code in modules, [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html) is not able to compile `import` statements to meets the way EdgeWorkers [import modules](https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-19D21814-AB04-49C8-AC25-28CCC9CC2D47.html) because all JavaScript module imports must include `.js` extension. Therefore, we need an additional build process to make our modules accessible in deployment. 
+
+This example demonstrates how to compile `.ts` files and bundle all modules and third-party dependencies into deployment-ready `main.js` file. 
+
+## Quick Start
+
+Please navigate to `typescript-module-bundle` example root,
+
+```bash
+cd edgeworkers-examples/typescript-module-bundle
+```
+
+and install dependencies with npm,
+
+```bash
+npm install
+```
+
+or with yarn,
+
+```bash
+yarn install
+```
+
+To build the project, please run
+
+```bash
+# with npm
+npm run build
+
+# or with yarn
+yarn build
+```
+
+The built files is located at `/dist` directory.
+
+To start dev mode, please run 
+
+```bash
+# with npm
+npm run start
+
+# or with yarn
+yarn start
+```
+
+## Resources
+
+See the repo [README](../README.md#Resources) for additional guidance.
+
+To learn more about setting up EdgeWorker with TypeScript, please see: 
+
+- [TypeScript](https://www.typescriptlang.org/)
+- [EdgeWorker User Guide: TypeScript](https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-EFA9EC25-AF64-4552-9D4D-BFE5E9D82752.html) 
+- [EdgeWorker User Guide: Use Case: Set up your Dev Environment](https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-ECA2B985-1AE7-4B47-A128-97203D6929D5.html?hl=typescript) 
+
+To learn more about Rollup.js and the plugins in this example, please see:
+
+- [rollup.js](https://rollupjs.org/guide/en/)
+- [Awesome Rollup](https://github.com/rollup/awesome)
+- [@rollup/plugin-typescript](https://github.com/rollup/plugins/tree/master/packages/typescript)
+- [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve)
+- [@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs)

--- a/typescript-module-bundle/package.json
+++ b/typescript-module-bundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-module-bundle",
   "version": "0.0.0",
-  "description": "Example of bundling EdgeWorker in TypeScript modules",
+  "description": "Example of bundling EdgeWorker with TypeScript modules",
   "license": "MIT",
   "scripts": {
     "start": "rollup -c -w",

--- a/typescript-module-bundle/package.json
+++ b/typescript-module-bundle/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "typescript-module-bundle",
+  "version": "0.0.0",
+  "description": "Example of bundling EdgeWorker in TypeScript modules",
+  "license": "MIT",
+  "scripts": {
+    "start": "rollup -c -w",
+    "build": "rollup -c && yarn build:bundle",
+    "build:bundle": "cp src/bundle.json dist/bundle.json"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^15.1.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-typescript": "^6.0.0",
+    "@types/akamai-edgeworkers": "^1.0.3",
+    "@types/md5": "^2.2.1",
+    "rollup": "^2.32.1",
+    "ts-jest": "^26.4.0",
+    "tslib": "^2.0.3",
+    "typescript": "^4.0.3"
+  },
+  "dependencies": {
+    "md5": "^2.3.0"
+  }
+}

--- a/typescript-module-bundle/rollup.config.js
+++ b/typescript-module-bundle/rollup.config.js
@@ -1,0 +1,12 @@
+import typescript from "@rollup/plugin-typescript";
+import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+
+export default {
+  input: "src/main.ts",
+  output: {
+    dir: "dist",
+    format: "es",
+  },
+  plugins: [typescript(), commonjs(), resolve()],
+};

--- a/typescript-module-bundle/src/bundle.json
+++ b/typescript-module-bundle/src/bundle.json
@@ -1,0 +1,4 @@
+{
+    "edgeworker-version": "0.1",
+    "description" : "Randomly assign new users to an A/B testing group.  Provides override functionality via query string parameter."
+}

--- a/typescript-module-bundle/src/bundle.json
+++ b/typescript-module-bundle/src/bundle.json
@@ -1,4 +1,4 @@
 {
-    "edgeworker-version": "0.1",
-    "description" : "Randomly assign new users to an A/B testing group.  Provides override functionality via query string parameter."
+  "edgeworker-version": "0.1",
+  "description": "Respond hello world markup with a hashed response header"
 }

--- a/typescript-module-bundle/src/hash.ts
+++ b/typescript-module-bundle/src/hash.ts
@@ -1,0 +1,5 @@
+import md5 from "md5";
+
+export function hash(message: string) {
+  return md5(message);
+}

--- a/typescript-module-bundle/src/main.ts
+++ b/typescript-module-bundle/src/main.ts
@@ -1,0 +1,26 @@
+import { hash } from "./hash";
+
+export function onClientRequest(
+  request: EW.ImmutableRequest & EW.HasRespondWith,
+  response: EW.Response
+) {
+  request.respondWith(
+    200,
+    {},
+    "<html><body><h1>Hello World From Akamai EdgeWorkers</h1></body></html>"
+  );
+}
+
+export function onClientResponse(
+  request: EW.ImmutableRequest,
+  response: EW.Response
+) {
+  /**
+   * Example of using custom modules. "hash" is a ES module in TypeScript and
+   * it consumes a CommonJS module. Rollup is able to bundle both type of
+   * modules into one single file "main.js" and it is ready for the rest of
+   * the build process and deployment.
+   */
+  const hashedMessage = hash("From Akamai EdgeWorkers");
+  response.setHeader("X-Hello-World", hashedMessage);
+}

--- a/typescript-module-bundle/src/main.ts
+++ b/typescript-module-bundle/src/main.ts
@@ -17,7 +17,7 @@ export function onClientResponse(
 ) {
   /**
    * Example of using custom modules. "hash" is a ES module in TypeScript and
-   * it consumes a CommonJS module. Rollup is able to bundle both type of
+   * it consumes a npm CommonJS module. Rollup is able to bundle both type of
    * modules into one single file "main.js" and it is ready for the rest of
    * the build process and deployment.
    */

--- a/typescript-module-bundle/tsconfig.json
+++ b/typescript-module-bundle/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "es6",
+    "target": "es6",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "sourceMap": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Overview

To introduce an example for TypeScript users on how to build deployment-ready EdgeWorker bundles with Rollup.js.

### Features
- Structure your codebase the way that fits your coding practice
- Bundle your codebase into one single `main.js` file that is ready for deployment
- Compatible with EdgeWorkers built-in modules
- Resolve CommonJS modules into ES modules

### Content

typescript-module-bundle
- `README.md`
- `/src`
  - `main.ts`
  - `hash.ts`
  - `bundle.json`
- `package.json`
- `tsconfig.json`
- `rollup.config.js`
