### PR TITLE
Fix bundle.json reference in rolluup config

### DIFF
--- a/edgeworkers/examples/bundle-third-party-modules/storelocator/rollup.config.js
+++ b/edgeworkers/examples/bundle-third-party-modules/storelocator/rollup.config.js
@@ -24,7 +24,7 @@ export default {
     // Copy bundle.json to the output directory
     copy({
       assets: [
-        'bundle.json'
+        './bundle.json'
       ]
     }),
     // Package json data as an ES6 module


### PR DESCRIPTION
Change "bundle.json" to "./bundle.json" to correct an error when building.  With the current line, the error received is “(!) Plugin copy-assets: Could not copy bundle.json because of an error: Error: ENOENT: no such file or directory, stat 'bundlejson'”