### PR TITLE
Ekv ab test

### DIFF
--- a/edgekv/examples/ab_testing/bundle.json
+++ b/edgekv/examples/ab_testing/bundle.json
@@ -1,0 +1,4 @@
+{
+    "edgeworker-version": "1.00",
+    "description" : "This EdgeWorker randomly places a user into one of two buckets (A or B). The bucket defines if the request is forwarded to either an experimental or control URL."
+}

--- a/edgekv/examples/ab_testing/edgekv_tokens.js
+++ b/edgekv/examples/ab_testing/edgekv_tokens.js
@@ -1,0 +1,7 @@
+var edgekv_access_tokens = {
+        "namespace-default": {
+            "name": "default_token",
+            "value": "insert_customer_token_here"
+        }
+}
+export { edgekv_access_tokens };

--- a/edgekv/examples/ab_testing/main.js
+++ b/edgekv/examples/ab_testing/main.js
@@ -2,8 +2,6 @@ import { Cookies, SetCookie } from 'cookies';
 import { logger } from 'log';
 import { EdgeKV } from './edgekv.js';
 const default_path = "ekv_experience/default";
-const bucketPathMap = new Map([["A", "ekv_experience/experiment-A"], 
-                               ["B", "ekv_experience/experiment-B"]]);
 const edgeKv_abpath = new EdgeKV({namespace: "default", group: "abpath"});
 
 export async function onClientRequest(request) {

--- a/edgekv/examples/ab_testing/main.js
+++ b/edgekv/examples/ab_testing/main.js
@@ -1,0 +1,86 @@
+import { Cookies, SetCookie } from 'cookies';
+import { logger } from 'log';
+import { EdgeKV } from './edgekv.js';
+const default_path = "ekv_experience/default";
+const edgeKv_abpath = new EdgeKV({namespace: "default", group: "abpath"});
+
+export async function onClientRequest(request) {
+    let cookies = new Cookies(request.getHeader('Cookie'));
+    let bucketCookie = cookies.get('bucket-id');
+    let requestUrl = request.url.toLowerCase();
+    let bucket_id = getBucketId(bucketCookie);
+    let abpath = await getBucketABPath(bucket_id);
+    let redir_path = getRedirect(abpath, requestUrl);
+
+    request.setVariable('PMUSER_EKV_ABTEST_EW', bucket_id);
+    request.route({
+        origin: request.host,
+        path: redir_path,
+    });
+}
+
+export function onClientResponse(request, response) {
+    // Retrieve the bucket_id from PMUSER var
+    let bucket_id = request.getVariable('PMUSER_EKV_ABTEST_EW');
+    if (!bucket_id) {
+        bucket_id = randBucket(); // Should not happen!
+    }
+    // Set bucket_id in cookie with 7 day expiry (A/B selections stickiness)
+    let expDate = new Date();
+    expDate.setDate(expDate.getDate() + 7);
+    let setBucketCookie = 
+        new SetCookie({name: "bucket-id", value: bucket_id, expires: expDate});
+    response.addHeader('Set-Cookie', setBucketCookie.toHeader());
+}
+
+function getRedirect(abpath, req_url) {
+    let relpath = '/' + abpath + '/';
+    return req_url.toLowerCase().replace("/edgekv/abtest", relpath);
+}
+
+function randBucket() {
+    let x = Math.random();
+    if (x < 0.5){
+        return 'A';
+    }
+    else {
+        return 'B';
+    }
+}
+
+function getBucketId(bucket_cookie) {
+    if (!bucket_cookie) {
+        return randBucket();
+    }
+    // Return a random bucket if cookie is not set
+    if (bucket_cookie.toUpperCase() == 'A') {
+        return 'A';
+    } else if (bucket_cookie.toUpperCase() == 'B') {
+        return 'B';
+    } else {
+        return randBucket();
+    }
+}
+
+async function getBucketABPath(bucket_id) {
+    // If we do not have a valid bucket, we will default to the following
+    if (!bucket_id) {
+        return default_path;
+    }
+    let path = null;
+    let err_msg = "";
+    // Retrieve the path associated with the bucket from EdgeKV
+    try {
+        path = await edgeKv_abpath.getText({ item: bucket_id.toUpperCase(), default_value: default_path });
+    } catch (error) {
+        // Catch the error and log the error message 
+        err_msg = error.toString();
+        logger.log("ERROR: " + 
+                encodeURI(err_msg).replace(/(%20|%0A|%7B|%22|%7D)/g, " "));
+        path = null;
+    }
+    if (!path) {
+        path = default_path;
+    }
+    return path;
+}

--- a/edgekv/examples/ab_testing/main.js
+++ b/edgekv/examples/ab_testing/main.js
@@ -2,6 +2,8 @@ import { Cookies, SetCookie } from 'cookies';
 import { logger } from 'log';
 import { EdgeKV } from './edgekv.js';
 const default_path = "ekv_experience/default";
+const bucketPathMap = new Map([["A", "ekv_experience/experiment-A"], 
+                               ["B", "ekv_experience/experiment-B"]]);
 const edgeKv_abpath = new EdgeKV({namespace: "default", group: "abpath"});
 
 export async function onClientRequest(request) {

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -1,4 +1,4 @@
-# AB Testing
+# A/B Test with EdgeWorkers and EdgeKV
 
 ## Copyright Notice
 (c) Copyright 2021 Akamai Technologies, Inc. Licensed under Apache 2 license.

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -13,7 +13,7 @@ This EdgeWorker randomly places a user into one of two buckets (A or B). The buc
 ## Property Manager Variables
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
 
-## EKV
+## EdgeKV
 EdgeKV *(namespace: default, group: abpath)* contains the required data to rewrite the incoming request in group.
 - Key: BucketName *(A or B)*
 - Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-A)*

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -14,6 +14,6 @@ This EdgeWorker randomly places a user into one of two buckets (A or B). The buc
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
 
 ## EKV
-EdgeKV stores the required info to rewrite the incoming request in group abpath.
-- Key: BucketName *(In this example: A or B)*
-- Value: Path *(In this example: ekv_experience/experiment-A or ekv_experience/experiment-A)*
+EdgeKV *(namespace: default, group: abpath)* contains the required data to rewrite the incoming request in group.
+- Key: BucketName *(A or B)*
+- Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-A)*

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -19,7 +19,11 @@ If you are new to EdgeKV first check the [Hello World Example](https://github.co
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
 
 ### EdgeKV
-EdgeKV *(namespace: default, group: abpath)* contains the required data to rewrite the incoming request in group.
+This example expects a working EdgeKV:
+- Namespace: default
+- Group: abpath
+
+Data:
 - Key: BucketName *(A or B)*
 - Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-A)*
 

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -19,13 +19,14 @@ If you are new to EdgeKV first check the [Hello World Example](https://github.co
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
 
 ### EdgeKV
-This example expects a working EdgeKV:
+This example expects a working EdgeKV instance with these settings:
+
 - Namespace: default
 - Group: abpath
 
-Data:
-- Key: BucketName *(A or B)*
-- Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-A)*
+This example expects data to be populated:
+- Key: BucketNames *(A or B)*
+- Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-B)*
 
 ### Origin
 This example rewrites URL's before sending them to the origin, make the endpoint of your rewrite actually exists. If not you will see 404 response codes.

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -9,3 +9,6 @@ This EdgeWorker randomly places a user into one of two buckets (A or B). The buc
 - The bucket-to-path mapping will be stored in an EdgeKV database
 - Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
 - The test will be implemented by redirecting a user accessing a website with a URI path of /edgekv/abtest. 
+
+## Property Manager Variables
+This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -10,6 +10,11 @@ This EdgeWorker randomly places a user into one of two buckets (A or B). The buc
 - Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
 - The test will be implemented by forwarding a user accessing a website with a URI path of /edgekv/abtest. 
 
+## Prerequisites
+If you are new to EdgeKV first check the [Hello World Example](https://github.com/akamai/edgeworkers-examples/tree/master/edgekv/examples/hello-world) with tips and best best practices to get started.
+
+## Setup
+
 ### Property Manager Variables
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
 
@@ -17,6 +22,9 @@ This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PM
 EdgeKV *(namespace: default, group: abpath)* contains the required data to rewrite the incoming request in group.
 - Key: BucketName *(A or B)*
 - Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-A)*
+
+### Origin
+This example rewrites URL's before sending them to the origin, make the endpoint of your rewrite actually exists. If not you will see 404 response codes.
 
 ## A step by Step Guide
 {{fill in}}

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -20,11 +20,14 @@ This example expects a working EdgeKV instance with these settings:
 
 - Namespace: default
 - Group: abpath
-
+- Keys: BuckeNames
 This example expects data to be populated:
-- Key: BucketNames *(A or B)*
-- Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-B)*
+- Key: The BucketName *(e.g. A or B)* Please note that keys are case sensitive
+- Value: The Path *(e.g. ekv_experience/experiment-A or ekv_experience/experiment-B)*
 
 ### Origin
 This example rewrites URL's before sending them to the origin, make the endpoint of your rewrite actually exists. If not you will see 404 response codes.
+This example assumes the EW is configured using the relative path "/edgekv/abtest", please update function *getRedirect()* accordingly.
+
+
 

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -1,6 +1,11 @@
-#
-This EdgeWorker randomly places a user into one of two “buckets'' (A or B), and forwards the request to either an experimental or control URL, depending on the bucket they are assigned to. 
+# AB Testing
 
-The bucket-to-path mapping will be stored in an EdgeKV database, and
-Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
-The test will be implemented by redirecting a user accessing a website with a URI path of /edgekv/abtest. 
+## Copyright Notice
+(c) Copyright 2021 Akamai Technologies, Inc. Licensed under Apache 2 license.
+
+## Overview
+This EdgeWorker randomly places a user into one of two buckets (A or B). The bucket defines if the request is forwarded to either an experimental or control URL.
+
+- The bucket-to-path mapping will be stored in an EdgeKV database
+- Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
+- The test will be implemented by redirecting a user accessing a website with a URI path of /edgekv/abtest. 

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -15,9 +15,6 @@ If you are new to EdgeKV first check the [Hello World Example](https://github.co
 
 ## Setup
 
-### Property Manager Variables
-This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
-
 ### EdgeKV
 This example expects a working EdgeKV instance with these settings:
 
@@ -30,7 +27,4 @@ This example expects data to be populated:
 
 ### Origin
 This example rewrites URL's before sending them to the origin, make the endpoint of your rewrite actually exists. If not you will see 404 response codes.
-
-## A step by Step Guide
-{{fill in}}
 

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -10,10 +10,14 @@ This EdgeWorker randomly places a user into one of two buckets (A or B). The buc
 - Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
 - The test will be implemented by forwarding a user accessing a website with a URI path of /edgekv/abtest. 
 
-## Property Manager Variables
+### Property Manager Variables
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
 
-## EdgeKV
+### EdgeKV
 EdgeKV *(namespace: default, group: abpath)* contains the required data to rewrite the incoming request in group.
 - Key: BucketName *(A or B)*
 - Value: Path *(ekv_experience/experiment-A or ekv_experience/experiment-A)*
+
+## A step by Step Guide
+{{fill in}}
+

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -1,0 +1,6 @@
+#
+This EdgeWorker randomly places a user into one of two “buckets'' (A or B), and forwards the request to either an experimental or control URL, depending on the bucket they are assigned to. 
+
+The bucket-to-path mapping will be stored in an EdgeKV database, and
+Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
+The test will be implemented by redirecting a user accessing a website with a URI path of /edgekv/abtest. 

--- a/edgekv/examples/ab_testing/readme.md
+++ b/edgekv/examples/ab_testing/readme.md
@@ -8,7 +8,12 @@ This EdgeWorker randomly places a user into one of two buckets (A or B). The buc
 
 - The bucket-to-path mapping will be stored in an EdgeKV database
 - Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits. 
-- The test will be implemented by redirecting a user accessing a website with a URI path of /edgekv/abtest. 
+- The test will be implemented by forwarding a user accessing a website with a URI path of /edgekv/abtest. 
 
 ## Property Manager Variables
 This EdgeWorker requires a PMUSER variable to be defined in Property Manager: PMUSER_EKV_ABTEST_EW
+
+## EKV
+EdgeKV stores the required info to rewrite the incoming request in group abpath.
+- Key: BucketName *(In this example: A or B)*
+- Value: Path *(In this example: ekv_experience/experiment-A or ekv_experience/experiment-A)*


### PR DESCRIPTION
This EdgeWorker randomly places a user into one of two buckets (A or B). The bucket defines if the request is forwarded to either an experimental or control URL.

The bucket-to-path mapping will be stored in an EdgeKV database
Client bucket selection will be persisted via a cookie value to ensure a client is locked to the same URL on subsequent visits.
The test will be implemented by forwarding a user accessing a website with a URI path of /edgekv/abtest.