### PR TITLE
fix search by id and typo error in EW examples

### DIFF
--- a/edgeworkers/examples/control-cache/cachekey-devicetype/main.js
+++ b/edgeworkers/examples/control-cache/cachekey-devicetype/main.js
@@ -13,5 +13,5 @@ export function onClientRequest (request) {
   } else if (request.device.isTablet) {
     request.setVariable('PMUSER_DEVICETYPE', 'Tablet');
   }
-  request.cachekey.includeVariable('PMUSER_DEVICETYPE');
+  request.cacheKey.includeVariable('PMUSER_DEVICETYPE');
 }

--- a/edgeworkers/examples/respond-from-edgeworkers/respondwith/commerce-categories/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/respondwith/commerce-categories/main.js
@@ -46,7 +46,7 @@ export function onClientRequest (request) {
     const search = params.get('search');
     if (search) {
       const re = new RegExp(search, 'i');
-      var data = categories.filter(el => el.title.match(re) || el.desc.match(re) || el.id === search);
+      var data = categories.filter(el => el.title.match(re) || el.desc.match(re) || el.id === parseInt(search));
       request.respondWith(200, { 'Content-Type': ['application/json'] }, JSON.stringify(data));
     }
   }

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js
@@ -25,7 +25,8 @@ export function responseProvider(request) {
             controller.enqueue(str2uint8arr(")"));
         }
     });
-  
+    
+    const options = { 'headers': {'Accept': 'application/json'} };
     return httpRequest(`${request.scheme}://${request.host}${request.path}?${params.toString()}`, options).then((response) => {
         return createResponse(
             response.status,


### PR DESCRIPTION
I noticed some minor issues in the following three edgeworker examples:

1. The cachekey-devicetype edgeworker example is not working on staging because of a typo in this line: https://github.com/akamai/edgeworkers-examples/blob/master/edgeworkers/examples/control-cache/cachekey-devicetype/main.js#L16.
2. Search by id is not working in commerce-categories EW example: https://github.com/akamai/edgeworkers-examples/blob/master/edgeworkers/examples/respond-from-edgeworkers/respondwith/commerce-categories/main.js#L49. When we search the categories by a valid id (e.g. 1150), we get an empty array in response even though a category exist with that id in the categories const.
3. The jsonp-wrapper EW example is failing because options constant is referenced without being defined in the responseProvider function: https://github.com/akamai/edgeworkers-examples/blob/master/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js#L29