### PR TITLE
trace-headers refactor

### DIFF
--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/README.md
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/README.md
@@ -1,0 +1,18 @@
+# trace-headers
+
+*Keyword(s):* response-provider, response-manipulation, debug-headers, trace-headers<br>
+
+<!-- *[Since](https://learn.akamai.com/en-us/webhelp/edgeworkers/edgeworkers-user-guide/GUID-14077BCA-0D9F-422C-8273-2F3E37339D5B.html):* 1.0 -->
+
+
+This example demonstrates how an **EdgeWorker** can be used to inspect the forward request headers that go through to an Origin (or Parent server) during the lifetime of a request. 
+
+The default example will output the request headers as part of the final response headers to the requestor, and prepend `x-fwd-` to the header name.
+If the `getForwardHeaders=body` query string parameter is sent in the original request, the EdgeWorker will *discard the real response body*, and instead output the Request + Response headers as the entire response body. **This should only be used for debugging purposes.**
+
+ 
+ 
+## More details on EdgeWorkers
+- [Akamai EdgeWorkers](https://developer.akamai.com/akamai-edgeworkers-overview)
+- [Akamai EdgeWorkers Examples](https://github.com/akamai/edgeworkers-examples)
+- [Akamai CLI for EdgeWorkers](https://developer.akamai.com/legacy/cli/packages/edgeworkers.html)

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/bundle.json
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/bundle.json
@@ -1,0 +1,1 @@
+{"edgeworker-version": "1.0", "description": "Get request/Response headers and respond with a body full of them, or just headers"}

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -88,7 +88,7 @@ export function responseProvider (request) {
 	options.headers = request.getHeaders();
 	delete options.headers["pragma"];
 	delete options.headers["accept-encoding"];
-	//delete options.headers['pragma']
+	
 	const reqUrl = request.scheme + '://' + request.host + request.url;
 	let hdrs = request.getHeaders();
 	return httpRequest(`${reqUrl}`, options).then(response => {

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -12,7 +12,6 @@ import { httpRequest } from 'http-request';
 import { createResponse } from 'create-response';
 import URLSearchParams from 'url-search-params';
 
-// const headersToSanitize = ['content-encoding'];
 
 /* 
 Construct entire response body to include request and response headers

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -7,7 +7,6 @@ Repo:
 Notes: If query param: getForwardHeaders=body exists, it will output all the headers as the response body instead
 of the original body. Else it outputs them as response headers with a prefix: x-fwd-
 */
-// import { logger } from 'log'; // Import the logger module
 import { httpRequest } from 'http-request';
 import { createResponse } from 'create-response';
 import URLSearchParams from 'url-search-params';

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -1,0 +1,110 @@
+/*
+(c) Copyright 2021 Akamai Technologies, Inc. Licensed under Apache 2 license.
+
+Version: 1.1
+Purpose:  Shows Forward request headers via responseProvider
+Repo: 
+Notes: If query param: getForwardHeaders=body exists, it will output all the headers as the response body instead
+of the original body. Else it outputs them as response headers with a prefix: x-fwd-
+*/
+// import { logger } from 'log'; // Import the logger module
+import { httpRequest } from 'http-request';
+import { createResponse } from 'create-response';
+import URLSearchParams from 'url-search-params';
+
+// const headersToSanitize = ['content-encoding'];
+
+/* 
+Construct entire response body to include request and response headers
+*/
+function constructResponseBody(request,response){
+	let responseBody = "<html><body><h2>Request Headers:</h2><br>";
+
+	// Get Request headers and append to response body
+	Object.keys(request.getHeaders()).forEach((key) => {
+		request.getHeaders()[key].forEach((headerval) => {
+			responseBody += key + ": " + headerval + " <br>";
+		});
+	});
+	
+	responseBody += "<br><h2>Response Headers:</h2><br>";
+	
+	// Get Response headers and append to response body
+	Object.keys(response.getHeaders()).forEach((key) => {
+		response.getHeaders()[key].forEach((headerval) => {
+			responseBody += key + ": " + headerval + " <br>";
+		});
+	});
+	
+	responseBody += "</body></html>";
+	return responseBody;
+}
+
+
+/* 
+Construct response headers by adding request headers prepended by x-fwd-
+*/
+
+function constructResponseHeaders(request, response){
+
+	var finalHeaders = response.getHeaders();//header array we'll eventually print, plus our own
+	
+	if (!finalHeaders) {
+		finalHeaders = {}
+	}
+	//We look at all the request headers, and for each, we prepend x-fwd- and add them to the response headers array
+	Object.keys(request.getHeaders()).forEach((headerName) => {
+		const valuesForHeaderName = request.getHeaders()[headerName];
+		var newHeaderName = 'x-fwd-' + headerName;
+		finalHeaders[newHeaderName] = [];
+		valuesForHeaderName.forEach((headerVal) => {
+			finalHeaders[newHeaderName].push(headerVal);
+		});
+	});
+
+	return finalHeaders;
+}
+
+/* 
+Determines if query parameter getForwardHeaders=body exists. If exists, returns all headers in a constructed 
+response body. Else, it returns request headers in the response headers, prepended by x-fwd-
+*/
+function returnInBody(request){
+	const queryParamName = 'getForwardHeaders';
+	const params = new URLSearchParams(request.query);
+	const paramValue = params.get(queryParamName);
+	if (paramValue) {
+		if (paramValue == "body") {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function responseProvider (request) {
+	const options = {}
+	
+	options.method = request.method;
+	options.headers = request.getHeaders();
+	delete options.headers["pragma"];
+	delete options.headers["accept-encoding"];
+	//delete options.headers['pragma']
+	const reqUrl = request.scheme + '://' + request.host + request.url;
+	let hdrs = request.getHeaders();
+	return httpRequest(`${reqUrl}`, options).then(response => {
+		if (returnInBody(request)){
+			return createResponse(
+				response.status,
+				response.headers,
+				constructResponseBody(request, response)
+				);
+		}else{
+			return createResponse(
+				response.status,
+				constructResponseHeaders(request, response),
+				response.body
+				);
+		}
+	});
+
+}


### PR DESCRIPTION
A simple EdgeWorker that captures forward request headers and outputs them back in the client response with a prefix, or as the response body. This is a tool meant for testing/debugging purposes.

Refactoring in response to [https://github.com/akamai/edgeworkers-examples/pull/78](url)
