### PR TITLE
Changed response.headers to response.getHeaders() - there is no 'headers' member in EW HttpResponse.

### DIFF
--- a/edgekv/examples/hello-world/main.js
+++ b/edgekv/examples/hello-world/main.js
@@ -71,7 +71,7 @@ async function hello_world_response(request) {
     
     // Send Response
     return createResponse(response.status,
-                          response.headers,
+                          response.getHeaders(),
                           response.body);
 }
 

--- a/edgekv/examples/hello-world/main.js
+++ b/edgekv/examples/hello-world/main.js
@@ -71,7 +71,7 @@ async function hello_world_response(request) {
     
     // Send Response
     return createResponse(response.status,
-                          response.getHeaders(),
+                          response.headers,
                           response.body);
 }
 

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js
@@ -30,7 +30,7 @@ export function responseProvider(request) {
     return httpRequest(`${request.scheme}://${request.host}${request.path}?${params.toString()}`, options).then((response) => {
         return createResponse(
             response.status,
-            response.headers,
+            response.getHeaders(),
             response.body.pipeThrough(jsonpTransformer)
         );
     });

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/jsonp-wrapper/main.js
@@ -30,7 +30,7 @@ export function responseProvider(request) {
     return httpRequest(`${request.scheme}://${request.host}${request.path}?${params.toString()}`, options).then((response) => {
         return createResponse(
             response.status,
-            response.getHeaders(),
+            {},
             response.body.pipeThrough(jsonpTransformer)
         );
     });

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/response-manipulation-stream/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/response-manipulation-stream/main.js
@@ -52,7 +52,7 @@ export function responseProvider (request) {
   return httpRequest(`${request.scheme}://${request.host}${request.url}`).then(response => {
     return createResponse(
       response.status,
-      response.headers,
+      response.getHeaders(),
       response.body.pipeThrough(new TextDecoderStream()).pipeThrough(new HTMLStream()).pipeThrough(new TextEncoderStream())
     );
   });

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/response-manipulation-stream/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/response-manipulation-stream/main.js
@@ -52,7 +52,7 @@ export function responseProvider (request) {
   return httpRequest(`${request.scheme}://${request.host}${request.url}`).then(response => {
     return createResponse(
       response.status,
-      response.getHeaders(),
+      {},
       response.body.pipeThrough(new TextDecoderStream()).pipeThrough(new HTMLStream()).pipeThrough(new TextEncoderStream())
     );
   });

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -93,7 +93,7 @@ export function responseProvider (request) {
 		if (returnInBody(request)){
 			return createResponse(
 				response.status,
-				response.getHeaders(),
+				{},
 				constructResponseBody(request, response)
 				);
 		}else{

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -93,7 +93,7 @@ export function responseProvider (request) {
 		if (returnInBody(request)){
 			return createResponse(
 				response.status,
-				response.headers,
+				response.getHeaders(),
 				constructResponseBody(request, response)
 				);
 		}else{

--- a/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
+++ b/edgeworkers/examples/respond-from-edgeworkers/responseprovider/trace-headers/main.js
@@ -93,7 +93,7 @@ export function responseProvider (request) {
 		if (returnInBody(request)){
 			return createResponse(
 				response.status,
-				{},
+				response.getHeaders(),
 				constructResponseBody(request, response)
 				);
 		}else{


### PR DESCRIPTION
Changed response.headers to response.getHeaders() 
There is no 'headers' member in EW HttpResponse, so the codes should use response.getHeaders() in order to include all origin response headers to the Edge response.
