### PR TITLE
fixed 404 issue with old file hierachary

### DIFF
--- a/edgeworkers/examples/work-with-cookies/cookie-geolocation/README.md
+++ b/edgeworkers/examples/work-with-cookies/cookie-geolocation/README.md
@@ -21,7 +21,7 @@ Set-Cookie: salesRegion=Midwest%3A68329004; Max-Age=86400; Path=/
 ````
 ## Similar Uses
 
-Geolocation can be also be performed in a separate service call, as in the [microservice-geolocation](../microservice-geolocation/) example.
+Geolocation can be also be performed in a separate service call, as in the [microservice-geolocation](../../respond-from-edgeworkers/respondwith/microservice-geolocation/) example.
 
 ## Resources
 See the repo [README](https://github.com/akamai/edgeworkers-examples#Resources) for additional guidance.


### PR DESCRIPTION
Hi, @steven scian and @tvereecke,  

You re-organized the file structure, so many 404s in older ref link, e..g this one here:
old and obsolete = /edgeworkers-examples/tree/master/edgeworkers/examples/work-with-cookies/microservice-geolocation (404 now) 

new and correct = /edgeworkers-examples/tree/master/edgeworkers/examples/respond-from-edgeworkers/respondwith/microservice-geolocation 

FYI 

Walter