### PR TITLE
response-manipulation: Support async transform

### DIFF
--- a/edgecompute/examples/stream/response-manipulation/main.js
+++ b/edgecompute/examples/stream/response-manipulation/main.js
@@ -46,9 +46,10 @@ class HTMLStream {
     this.writable = new WritableStream({
       write (text) {
         completeProcessing = handleTemplate(text, 0);
+        return completeProcessing;
       },
       close (controller) {
-        completeProcessing.then(() => readController.close());
+        return completeProcessing.then(() => readController.close());
       }
     });
   }


### PR DESCRIPTION
When WritableStream.write() and WritableStream.close() contain async code, they should return the Promise, indicating completion.

When this example is modified to make HTTP Requests during processing, it did not wait for the response before processing and returning the next chunk.