### PR TITLE
Update edgekv.js checking for token without namespace prefix

### DIFF
--- a/edgekv/lib/edgekv.js
+++ b/edgekv/lib/edgekv.js
@@ -128,7 +128,10 @@ export class EdgeKV {
 		}
 		let name = "namespace-" + namespace;
 		if (!(name in edgekv_access_tokens)) {
-			throw "MISSING ACCESS TOKEN. No EdgeKV Access Token defined for namespace '" + namespace + "'.";
+			name = namespace;
+			if (!(name in edgekv_access_tokens)) {
+				throw "MISSING ACCESS TOKEN. No EdgeKV Access Token defined for namespace '" + namespace + "'.";
+			}
 		}
 		if ("value" in edgekv_access_tokens[name]) {
 			return { 'X-Akamai-EdgeDB-Auth': [edgekv_access_tokens[name]["value"]]};


### PR DESCRIPTION
`namespace-` prefix is not added to token properties by current akamai edgekv CLI. This incompatibility leads to execution errors in EdgeWorkers that are not easy to debug.